### PR TITLE
feat: added an example section for citations and references

### DIFF
--- a/settings/settings_base.tex
+++ b/settings/settings_base.tex
@@ -331,4 +331,7 @@ bibencoding=auto
 \input{structure/3-tail/ch3_glossary}
 \makeglossaries
 
+% Citation or text references
+\usepackage{tcolorbox}
+
 %TC:endignore

--- a/structure/2-main/ch2_analysis.tex
+++ b/structure/2-main/ch2_analysis.tex
@@ -119,6 +119,19 @@ There is the possibility to insert custom boxes like \marginpar{IMPORTANT} infor
 \end{warning}
 
 % -----------------------------------------------------------------------------
+\subsection{Citation or text references}
+\begin{tcolorbox}[
+    colback=white,
+    colframe=languidlavender,
+    sharp corners,
+    title={\textit{Citation}},
+    fonttitle=\bfseries\color{black}
+]
+\textit{"\lipsum[1][1]"} \\[1ex]
+\hfill \textit{John Doe and Jane Doe}
+\end{tcolorbox}
+
+% -----------------------------------------------------------------------------
 \subsection{Other features}
 
 Term (glossaries): \gls{nosql}
@@ -129,6 +142,7 @@ Citation (biblatex): \cite{paper_millwheel}
 
 \href{https://en.wikipedia.org/wiki/Cat}{Cat}: 
 \url{https://en.wikipedia.org/wiki/Cat}
+
 
 % -----------------------------------------------------------------------------
 \section{Conclusion}


### PR DESCRIPTION
## Feature: Added Example Section for Citations and References

### Summary

This pull request introduces a new section in the LaTeX document demonstrating how to use citations and references properly. The goal is to provide a clear, reusable example for future contributors or readers.

### Changes Made

- Added an example section in `ch2_analysis.tex` illustrating the use of `\begin{tcolorbox}` commands
- Updated `settings_base.tex` to use the tcolorbox package
- Ensured compilation works without warnings or errors

### Motivation

Citations and references are essential in structured academic writing. This section helps maintain consistency and provides guidance for citing sources or referring to figures, tables, or sections throughout the document.

### Notes

- Please double-check that the bibliography file is properly linked
- Let me know if there's a preferred citation style to apply globally

### Visual Result
![feat-add_citation-block](https://github.com/user-attachments/assets/a5bbd28a-b0d9-41f1-aa44-e193cf8200ef)

